### PR TITLE
Fix keepalive service bypassing the hardware write lock

### DIFF
--- a/app/src/main/java/com/freefcc/app/FccKeepaliveService.kt
+++ b/app/src/main/java/com/freefcc/app/FccKeepaliveService.kt
@@ -81,17 +81,22 @@ class FccKeepaliveService : Service() {
         keepaliveJob?.cancel()
         keepaliveJob = scope.launch {
             while (true) {
-                try {
-                    val profile = Profiles.load(this@FccKeepaliveService, "fcc_keepalive.json")
-                    transport.sendFrames(
-                        frames = profile.frames,
-                        rounds = 1,
-                        interFrameDelayMs = profile.interFrameDelay,
-                        readWindowMs = profile.readWindowMs,
-                        port = profile.port
-                    )
-                } catch (_: Exception) {
+                if (HardwareLock.tryBegin()) {
+                    try {
+                        val profile = Profiles.load(this@FccKeepaliveService, "fcc_keepalive.json")
+                        transport.sendFrames(
+                            frames = profile.frames,
+                            rounds = 1,
+                            interFrameDelayMs = profile.interFrameDelay,
+                            readWindowMs = profile.readWindowMs,
+                            port = profile.port
+                        )
+                    } catch (_: Exception) {
+                    } finally {
+                        HardwareLock.end()
+                    }
                 }
+                // else: a manual operation (or another tick) holds the lock — skip this tick, never queue/block.
                 delay(2000)
             }
         }

--- a/app/src/main/java/com/freefcc/app/FccViewModel.kt
+++ b/app/src/main/java/com/freefcc/app/FccViewModel.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -75,23 +74,17 @@ class FccViewModel(private val app: Application) : AndroidViewModel(app) {
     private val transport = DumplTransport()
     private val prefs = app.getSharedPreferences("freefcc", Context.MODE_PRIVATE)
 
-    /** Serializes every controller-/aircraft-facing operation so frames never overlap. */
-    private val hardwareMutex = Mutex()
+    /** Claims the shared hardware lock for one operation. Returns false if another (including the keepalive service) is already running. */
+    private fun beginHardwareOp(): Boolean = HardwareLock.tryBegin()
 
-    /** Claims the hardware lock for one operation. Returns false if another is already running. */
-    private fun beginHardwareOp(): Boolean {
-        if (!hardwareMutex.tryLock()) return false
-        update { copy(isHardwareBusy = true) }
-        return true
-    }
-
-    /** Releases the hardware lock. Must run in a finally block covering every exit path. */
-    private fun endHardwareOp() {
-        update { copy(isHardwareBusy = false) }
-        hardwareMutex.unlock()
-    }
+    /** Releases the shared hardware lock. Must run in a finally block covering every exit path. */
+    private fun endHardwareOp() = HardwareLock.end()
 
     fun init() {
+        viewModelScope.launch {
+            HardwareLock.busy.collect { busy -> update { copy(isHardwareBusy = busy) } }
+        }
+
         val model = try { Build.DEVICE } catch (_: Exception) { "unknown" }
         val autoEnabled = prefs.getBoolean("auto_fcc", false)
         update { copy(controllerModel = model, status = "disconnected", autoFcc = autoEnabled) }

--- a/app/src/main/java/com/freefcc/app/FccViewModel.kt
+++ b/app/src/main/java/com/freefcc/app/FccViewModel.kt
@@ -74,6 +74,15 @@ class FccViewModel(private val app: Application) : AndroidViewModel(app) {
     private val transport = DumplTransport()
     private val prefs = app.getSharedPreferences("freefcc", Context.MODE_PRIVATE)
 
+    init {
+        // MainActivity.onCreate() calls init() below on every Activity re-creation
+        // (e.g. config change), but this class init{} runs exactly once per
+        // ViewModel instance — the collector must live here, not in init().
+        viewModelScope.launch {
+            HardwareLock.busy.collect { busy -> update { copy(isHardwareBusy = busy) } }
+        }
+    }
+
     /** Claims the shared hardware lock for one operation. Returns false if another (including the keepalive service) is already running. */
     private fun beginHardwareOp(): Boolean = HardwareLock.tryBegin()
 
@@ -81,10 +90,6 @@ class FccViewModel(private val app: Application) : AndroidViewModel(app) {
     private fun endHardwareOp() = HardwareLock.end()
 
     fun init() {
-        viewModelScope.launch {
-            HardwareLock.busy.collect { busy -> update { copy(isHardwareBusy = busy) } }
-        }
-
         val model = try { Build.DEVICE } catch (_: Exception) { "unknown" }
         val autoEnabled = prefs.getBoolean("auto_fcc", false)
         update { copy(controllerModel = model, status = "disconnected", autoFcc = autoEnabled) }

--- a/app/src/main/java/com/freefcc/app/HardwareLock.kt
+++ b/app/src/main/java/com/freefcc/app/HardwareLock.kt
@@ -1,0 +1,34 @@
+package com.freefcc.app
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+
+/**
+ * Process-wide serialization for every controller-/aircraft-facing DUMPL write.
+ *
+ * [FccViewModel] (UI-triggered operations) and [FccKeepaliveService] (background
+ * re-apply loop) are separate Android components with no shared instance, so the
+ * lock lives here as a singleton both can reach. [busy] mirrors who currently
+ * holds it, so the UI reflects service writes too.
+ */
+object HardwareLock {
+
+    private val mutex = Mutex()
+    private val _busy = MutableStateFlow(false)
+    val busy: StateFlow<Boolean> = _busy.asStateFlow()
+
+    /** Claims the lock for one operation. Returns false if another is already running. */
+    fun tryBegin(): Boolean {
+        if (!mutex.tryLock()) return false
+        _busy.value = true
+        return true
+    }
+
+    /** Releases the lock. Must run in a finally block covering every exit path. */
+    fun end() {
+        _busy.value = false
+        mutex.unlock()
+    }
+}

--- a/app/src/test/java/com/freefcc/app/HardwareLockTest.kt
+++ b/app/src/test/java/com/freefcc/app/HardwareLockTest.kt
@@ -1,0 +1,47 @@
+package com.freefcc.app
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Covers HardwareLock's mutual exclusion — the guarantee S-006 relies on to stop
+ * FccKeepaliveService writing DUMPL frames while FccViewModel holds the lock (or
+ * vice versa). The held lock is only released after the concurrent tryBegin()
+ * attempt has actually run, via CountDownLatch, so "exactly one wins" can't pass
+ * by accident from a lock that was already free by the time the second call ran.
+ */
+class HardwareLockTest {
+
+    @Test
+    fun secondTryBeginFailsWhileFirstHoldsTheLock() {
+        assertTrue("lock must be free at test start", HardwareLock.tryBegin())
+        assertTrue(HardwareLock.busy.value)
+
+        val secondAttempted = CountDownLatch(1)
+        val secondResult = AtomicBoolean(true)
+
+        val secondThread = Thread {
+            secondResult.set(HardwareLock.tryBegin())
+            secondAttempted.countDown()
+        }
+        secondThread.start()
+
+        assertTrue(
+            "second thread's tryBegin() never ran",
+            secondAttempted.await(5, TimeUnit.SECONDS)
+        )
+        secondThread.join(5000)
+
+        assertFalse("second tryBegin() must fail while the first op still holds the lock", secondResult.get())
+
+        HardwareLock.end()
+        assertFalse(HardwareLock.busy.value)
+        assertTrue("lock must be free again after end()", HardwareLock.tryBegin())
+        HardwareLock.end()
+    }
+}

--- a/app/src/test/java/com/freefcc/app/HardwareLockTest.kt
+++ b/app/src/test/java/com/freefcc/app/HardwareLockTest.kt
@@ -1,6 +1,5 @@
 package com.freefcc.app
 
-import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -19,29 +18,39 @@ class HardwareLockTest {
 
     @Test
     fun secondTryBeginFailsWhileFirstHoldsTheLock() {
-        assertTrue("lock must be free at test start", HardwareLock.tryBegin())
-        assertTrue(HardwareLock.busy.value)
+        val firstAcquired = HardwareLock.tryBegin()
+        try {
+            assertTrue("lock must be free at test start", firstAcquired)
+            assertTrue(HardwareLock.busy.value)
 
-        val secondAttempted = CountDownLatch(1)
-        val secondResult = AtomicBoolean(true)
+            val secondAttempted = CountDownLatch(1)
+            val secondResult = AtomicBoolean(true)
 
-        val secondThread = Thread {
-            secondResult.set(HardwareLock.tryBegin())
-            secondAttempted.countDown()
+            val secondThread = Thread {
+                secondResult.set(HardwareLock.tryBegin())
+                secondAttempted.countDown()
+            }
+            secondThread.start()
+
+            assertTrue(
+                "second thread's tryBegin() never ran",
+                secondAttempted.await(5, TimeUnit.SECONDS)
+            )
+            secondThread.join(5000)
+
+            assertFalse("second tryBegin() must fail while the first op still holds the lock", secondResult.get())
+        } finally {
+            // Only release what this test actually acquired — never unlock on behalf
+            // of another op, and never leak the lock into later tests on assertion failure.
+            if (firstAcquired) HardwareLock.end()
         }
-        secondThread.start()
-
-        assertTrue(
-            "second thread's tryBegin() never ran",
-            secondAttempted.await(5, TimeUnit.SECONDS)
-        )
-        secondThread.join(5000)
-
-        assertFalse("second tryBegin() must fail while the first op still holds the lock", secondResult.get())
-
-        HardwareLock.end()
         assertFalse(HardwareLock.busy.value)
-        assertTrue("lock must be free again after end()", HardwareLock.tryBegin())
-        HardwareLock.end()
+
+        val reacquired = HardwareLock.tryBegin()
+        try {
+            assertTrue("lock must be free again after end()", reacquired)
+        } finally {
+            if (reacquired) HardwareLock.end()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- `FccKeepaliveService` ran its own `DumplTransport` on a 2s loop with no relation to `FccViewModel`'s hardware mutex, so keepalive frames could be written concurrently with any manual FCC/CE/4G/LED/device-info operation.
- Extracted the lock into a `HardwareLock` singleton object that both `FccViewModel` and `FccKeepaliveService` delegate to (they're separate Android components with no shared instance, so a process-wide singleton is the natural fit).
- Keepalive skips a tick (never blocks/queues) when the lock is already held, matching the existing non-blocking `tryLock()` behavior used by every other hardware entry point.
- `isHardwareBusy` now mirrors the shared lock's state via a `StateFlow`, so the UI correctly shows busy while the keepalive service is writing too.
- No changes to the DUMPL frame/wire format.

## Test plan
- [x] `HardwareLockTest` — new deterministic concurrency test: a second thread's `tryBegin()` is proven to run (via `CountDownLatch`) while the first holds the lock before it's released, so the "exactly one wins" assertion can't pass by accident from sequential timing.
- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL, 9/9 existing DUMPL tests + 1/1 new HardwareLock test, all green.
- [x] `./gradlew compileDebugKotlin` — BUILD SUCCESSFUL.