### PR TITLE
Fix signed-release CI job to check the keystore secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,7 @@ jobs:
 
     env:
       SIGNING_STORE_FILE: ${{ runner.temp }}/release.jks
+      SIGNING_KEYSTORE_B64: ${{ secrets.SIGNING_KEYSTORE_B64 }}
       SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
       SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
       SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
@@ -67,7 +68,7 @@ jobs:
       - name: Check signing secrets are present
         id: secrets
         run: |
-          if [ -z "$SIGNING_STORE_PASSWORD" ] || [ -z "$SIGNING_KEY_ALIAS" ] || [ -z "$SIGNING_KEY_PASSWORD" ]; then
+          if [ -z "$SIGNING_KEYSTORE_B64" ] || [ -z "$SIGNING_STORE_PASSWORD" ] || [ -z "$SIGNING_KEY_ALIAS" ] || [ -z "$SIGNING_KEY_PASSWORD" ]; then
             echo "have_secrets=false" >> "$GITHUB_OUTPUT"
             echo "Warning: signing secrets not configured — skipping signed build." >&2
           else
@@ -76,7 +77,7 @@ jobs:
 
       - name: Decode keystore
         if: steps.secrets.outputs.have_secrets == 'true'
-        run: echo "${{ secrets.SIGNING_KEYSTORE_B64 }}" | base64 --decode > "$SIGNING_STORE_FILE"
+        run: echo "$SIGNING_KEYSTORE_B64" | base64 --decode > "$SIGNING_STORE_FILE"
 
       - name: Assemble signed release
         if: steps.secrets.outputs.have_secrets == 'true'


### PR DESCRIPTION
## Summary
- The signed-release job's secret guard only checked `SIGNING_STORE_PASSWORD`/`SIGNING_KEY_ALIAS`/`SIGNING_KEY_PASSWORD`, never `SIGNING_KEYSTORE_B64`.
- If that one secret was missing, `base64 --decode` wrote an empty/invalid keystore file, and `assembleRelease` failed later with an opaque keytool/Gradle error instead of a clear skip.
- Added `SIGNING_KEYSTORE_B64` to the guard's `-z` checks and to the job's `env:` block (matching the other three secrets), and switched the decode step to use the env var instead of interpolating the secret directly into the shell script.
- No other changes — trigger, permissions, build job, and artifact upload steps are untouched.

## Test plan
- [x] YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`.
- [x] Guard logic traced for each of the four secrets missing individually (bash simulation) — all four correctly fall to `have_secrets=false`; all four present correctly gives `have_secrets=true`.