### PR TITLE
Fix sendFrames() reporting success on partial frame transmission

### DIFF
--- a/app/src/main/java/com/freefcc/app/DumlTransport.kt
+++ b/app/src/main/java/com/freefcc/app/DumlTransport.kt
@@ -225,9 +225,11 @@ class DumlTransport {
     /**
      * Sends a list of frames over multiple rounds, discarding ACKs.
      * Automatically finds the correct DUML port for the controller type.
+     * Attempts every frame regardless of earlier failures, but only
+     * returns true if every single write succeeded.
      *
      * @param onProgress Called with a 0..1 float as frames are sent
-     * @return true if at least one frame was written successfully
+     * @return true if every frame write succeeded (false for an empty frame list)
      */
     fun sendFrames(
         frames: List<ByteArray>,
@@ -238,19 +240,19 @@ class DumlTransport {
         port: Int = PORT,
         onProgress: (Float) -> Unit = {}
     ): Boolean {
+        if (frames.isEmpty()) return false
+
         // If port is the default (40009), scan for the actual working port.
         // If port is explicitly set (e.g. 40007 for LED), use it directly.
         val effectivePort = if (port == PORT) findWorkingPort() else port
 
-        var anySuccess = false
+        val results = mutableListOf<Boolean>()
         val totalSends = frames.size * rounds
         var sent = 0
 
         for (round in 0 until rounds) {
             for (frame in frames) {
-                if (sendOneFrame(frame, readWindowMs, effectivePort)) {
-                    anySuccess = true
-                }
+                results.add(sendOneFrame(frame, readWindowMs, effectivePort))
                 sent++
                 onProgress(sent.toFloat() / totalSends)
                 if (interFrameDelayMs > 0) Thread.sleep(interFrameDelayMs)
@@ -259,7 +261,7 @@ class DumlTransport {
                 Thread.sleep(interRoundDelayMs)
             }
         }
-        return anySuccess
+        return allFramesSucceeded(results)
     }
 
     /**
@@ -486,6 +488,10 @@ class DumlTransport {
 
         /** Settle delay after reading the ACK, before the next frame. */
         private const val POST_ACK_SETTLE_MS = 20L
+
+        /** True only if every send in the series succeeded and the series was non-empty. */
+        internal fun allFramesSucceeded(results: List<Boolean>): Boolean =
+            results.isNotEmpty() && results.all { it }
     }
 
     /** Reused read buffer for ACK reads — avoids a per-frame allocation. */

--- a/app/src/test/java/com/freefcc/app/DumlTransportSendFramesTest.kt
+++ b/app/src/test/java/com/freefcc/app/DumlTransportSendFramesTest.kt
@@ -1,0 +1,28 @@
+package com.freefcc.app
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers DumlTransport.allFramesSucceeded() — the aggregation rule Codex
+ * required for S-008: a non-empty send series must report success only if
+ * every single write succeeded; an empty series is always a failure.
+ */
+class DumlTransportSendFramesTest {
+
+    @Test
+    fun allWritesSucceeding_reportsSuccess() {
+        assertTrue(DumlTransport.allFramesSucceeded(listOf(true, true, true)))
+    }
+
+    @Test
+    fun oneFailedWriteAmongMany_reportsFailure() {
+        assertFalse(DumlTransport.allFramesSucceeded(listOf(true, false, true)))
+    }
+
+    @Test
+    fun emptySeries_reportsFailure() {
+        assertFalse(DumlTransport.allFramesSucceeded(emptyList()))
+    }
+}


### PR DESCRIPTION
## Problem

`sendFrames()` in `DumlTransport.kt` OR-accumulates success across every
frame×round write in its send loop and returns `true` if even one of them
succeeded. The FCC profile is 21 frames × 2 rounds = 42 writes; if the link
drops after the first write, the function still returns `true`. Callers like
`FccViewModel.enableFcc()` then set `isFccEnabled = true` and report "FCC
mode enabled" on a mostly-failed transmission.

## Fix

`sendFrames()` now requires every write in the series to succeed, and treats
an empty frame list as a failure — matching the pattern already used by
`sendFramesUnix()` (4G activation) in the same file. No changes to DUML
frames, ports, timing, or the ACK read.

The aggregation rule is extracted into a small `internal` function,
`allFramesSucceeded()`, so it's directly unit-testable without socket I/O.

Existing callers keep their current semantics:
- `enableFcc()` / `disableFcc()` (CE): each makes one `sendFrames()` call —
  now correctly requires the full profile to succeed.
- `setLed()`: already ORs the results of two separate `sendFrames()` calls
  itself (its own double-attempt retry); each individual attempt now
  correctly requires its own frames to fully succeed, but the outer
  "either attempt is enough" behavior is unchanged.
- Keepalive loop: never checked the return value and still doesn't — an
  incomplete tick already didn't claim success.

## Testing

- New `DumlTransportSendFramesTest`: complete series → success, one failure
  among many → failure, empty series → failure (3/3 passing).
- `./gradlew testDebugUnitTest`: 13/13 passing (existing `HardwareLockTest`,
  `DumlResponseValidationTest` unaffected).
- `./gradlew compileDebugKotlin`: clean.

Out of scope: the separate, already-known gap where a fully-written frame
series still isn't a confirmed radio-side status readback.