### PR TITLE
v1.5.4: fix 4G activation flag byte

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: build
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -40,7 +41,8 @@ jobs:
           if-no-files-found: error
 
   signed-release:
-    if: github.event_name == 'workflow_dispatch'
+    # Runs on a version tag push (v*) to sign + publish a release, or manually.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -94,3 +96,22 @@ jobs:
           name: release-signed-apk
           path: app/build/outputs/apk/release/*.apk
           if-no-files-found: error
+
+      # On a version tag, attach the signed APK to the GitHub Release.
+      # The signed build output is named app-release.apk, so the stable URL
+      # https://github.com/doesthings/FreeFCC/releases/latest/download/app-release.apk
+      # (used by the site and the in-app updater) keeps working automatically.
+      - name: Publish signed APK to the release
+        if: startsWith(github.ref, 'refs/tags/v') && steps.secrets.outputs.have_secrets == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          APK="app/build/outputs/apk/release/app-release.apk"
+          if [ ! -f "$APK" ]; then APK="$(ls app/build/outputs/apk/release/*.apk | head -1)"; fi
+          echo "Publishing $APK to release ${GITHUB_REF_NAME}"
+          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" "$APK" --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" "$APK" \
+              --title "${GITHUB_REF_NAME}" --generate-notes
+          fi

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.freefcc.app"
         minSdk = 29
         targetSdk = 35
-        versionCode = 20
-        versionName = "1.5.2"
+        versionCode = 21
+        versionName = "1.5.4"
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")

--- a/app/src/main/assets/profiles/4g.json
+++ b/app/src/main/assets/profiles/4g.json
@@ -14,7 +14,7 @@
   "cmd_id_start": 0,
   "dst": 238,
   "dst_desc": "OFDM_GROUND, index 7",
-  "payload_prefix_hex": "000000",
+  "payload_prefix_hex": "000001",
   "payload_serial_encoding": "ascii",
-  "note": "Each frame's payload is: 3 zero bytes + ASCII aircraft serial. Frame i has cmd_id=i (0..127). The serial is read from the controller at runtime via probeSerial()."
+  "note": "Each frame's payload is a 3-byte prefix (00 00 01) followed by the ASCII aircraft serial; the third prefix byte is the activation flag (00 = off, 01 = on). Frame i has cmd_id=i (0..127). The serial is read from the controller at runtime via probeSerial()."
 }

--- a/app/src/main/java/com/freefcc/app/FccViewModel.kt
+++ b/app/src/main/java/com/freefcc/app/FccViewModel.kt
@@ -65,7 +65,7 @@ data class AppState(
 class FccViewModel(private val app: Application) : AndroidViewModel(app) {
 
     companion object {
-        const val APP_VERSION = "1.5.2"
+        const val APP_VERSION = "1.5.4"
 
         /**
          * Aircraft model codes *hinted* to support the DJI Cellular Dongle 2 / 4G.


### PR DESCRIPTION
## What
- **4G activation flag fix.** The per-frame payload prefix was `00 00 00`; the third byte is the activation flag and must be `01`. Sending `00` made the 128 frames a no-op. Payload is now `00 00 01` + ASCII serial.
- Version bump 1.5.2 → 1.5.4 (versionCode 20 → 21).

## Why it matters
Combined with the gate fix that previously blocked 4G from being sent at all (#40), this is the first build where 4G can run end to end. **Still experimental** — needs on-hardware confirmation on a dongle-equipped aircraft.

## Safety
- FCC path untouched; 4G is gated and send-only.
- Built locally: `assembleRelease` + unit tests green.

## Release scope (v1.5.4 also bundles what's on `main` since v1.5.3)
- 4G gate fix (#40) — the gate could never pass for any aircraft
- Honest FCC/CE apply-success reporting
- CI build fix (builds were failing at startup)
- Download links point to the new site