### PR TITLE
v1.5.5: robust aircraft serial detection + manual entry

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,8 @@ android {
         applicationId = "com.freefcc.app"
         minSdk = 29
         targetSdk = 35
-        versionCode = 21
-        versionName = "1.5.4"
+        versionCode = 22
+        versionName = "1.5.5"
     }
 
     val keystorePropsFile = rootProject.file("keystore.properties")

--- a/app/src/main/java/com/freefcc/app/DumlTransport.kt
+++ b/app/src/main/java/com/freefcc/app/DumlTransport.kt
@@ -2,6 +2,7 @@ package com.freefcc.app
 
 import android.net.LocalSocket
 import android.net.LocalSocketAddress
+import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -352,12 +353,180 @@ class DumlTransport {
      * @return the serial string (empty if nothing matched within the window)
      */
     fun probeSerial(timeoutMs: Int = 1500): String {
-        // Try the full aircraft serial pattern first (1581 + 12-18 uppercase alphanumeric chars).
-        val result = listenForSerial(Regex("1581[0-9A-Z]{12,18}"), timeoutMs)
-        if (result.isNotEmpty()) return result
+        // Passive telemetry: accumulate raw bytes and extract the serial,
+        // including serials carried inside 55 CC 30 75 length-prefixed chunks
+        // (some firmware wraps the serial that way, so a plain regex misses it).
+        val passive = listenAndExtract(timeoutMs)
+        if (passive.isNotEmpty()) return passive
 
-        // Fallback: try the model code pattern (W[AM]xxx — e.g. WA341, WM630).
-        return listenForSerial(Regex("W[AM][0-9]{3}"), timeoutMs)
+        // Fallback: the short W[AM]xxx model code (some links only broadcast this).
+        return listenForSerial(Regex("W[AM][0-9]{3}"), minOf(timeoutMs, 1000))
+    }
+
+    // --- Serial detection: passive extraction + active query ---
+
+    /** Serial-query targets: aircraft flight controller (3), remote radio (6). */
+    private val serialQueryTargets = listOf(3, 6)
+    /** Version/serial inquiry command IDs in the GENERAL (cmdSet 0) set. */
+    private val serialQueryCmdIds = listOf(87, 1)
+    private val serialQueryBuilder = DumlBuilder()
+
+    /**
+     * Passively listens for telemetry and extracts the aircraft serial,
+     * reassembling 55 CC 30 75 length-prefixed chunks when present.
+     */
+    private fun listenAndExtract(timeoutMs: Int): String {
+        var socket: Socket? = null
+        try {
+            val port = findWorkingPort()
+            socket = Socket()
+            socket.connect(InetSocketAddress(HOST, port), CONNECT_TIMEOUT_MS)
+            socket.soTimeout = 200
+            val input = socket.getInputStream()
+            val acc = ByteArrayOutputStream()
+            val buf = ByteArray(8192)
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (System.currentTimeMillis() < deadline && acc.size() < 524288) {
+                try {
+                    val n = input.read(buf)
+                    if (n > 0) {
+                        acc.write(buf, 0, n)
+                        val s = extractSerial(acc.toByteArray())
+                        if (s.isNotEmpty()) return s
+                    } else if (n < 0) break
+                } catch (_: IOException) { /* read timeout — keep listening */ }
+            }
+        } catch (_: IOException) { /* connection failed */ }
+        finally { try { socket?.close() } catch (_: IOException) {} }
+        return ""
+    }
+
+    /**
+     * Actively asks the aircraft (then the controller radio) for its serial by
+     * sending a version/serial inquiry and reading the reply. Used when passive
+     * telemetry does not surface the serial (the most common field failure).
+     */
+    fun probeSerialActive(perQueryMs: Int = 800): String {
+        val port = findWorkingPort()
+        for (dst in serialQueryTargets) {
+            for (cmdId in serialQueryCmdIds) {
+                val frame = serialQueryBuilder.buildFrame(
+                    DumlFrame(sender = 42, cmdType = 0x40, cmdSet = 0, cmdId = cmdId, dst = dst, payload = ByteArray(0))
+                )
+                val raw = sendAndReadRaw(frame, perQueryMs, port)
+                if (raw.isEmpty()) continue
+                val fromFrame = parseQueryResponse(raw, cmdId)
+                if (fromFrame.isNotEmpty()) return fromFrame
+                val fromScan = extractSerial(raw)
+                if (fromScan.isNotEmpty()) return fromScan
+            }
+        }
+        return ""
+    }
+
+    /** Writes a frame then reads whatever the proxy returns within the window. */
+    private fun sendAndReadRaw(frame: ByteArray, windowMs: Int, port: Int): ByteArray {
+        var socket: Socket? = null
+        return try {
+            socket = Socket()
+            socket.connect(InetSocketAddress(HOST, port), CONNECT_TIMEOUT_MS)
+            socket.tcpNoDelay = true
+            socket.soTimeout = 120
+            socket.getOutputStream().apply { write(frame); flush() }
+            val input = socket.getInputStream()
+            val acc = ByteArrayOutputStream()
+            val buf = ByteArray(4096)
+            val deadline = System.currentTimeMillis() + windowMs
+            while (System.currentTimeMillis() < deadline && acc.size() < 65536) {
+                try {
+                    val n = input.read(buf)
+                    if (n > 0) acc.write(buf, 0, n) else if (n < 0) break
+                } catch (_: IOException) { /* keep reading until the window closes */ }
+            }
+            acc.toByteArray()
+        } catch (_: IOException) { ByteArray(0) }
+        finally { try { socket?.close() } catch (_: IOException) {} }
+    }
+
+    /**
+     * Parses DUML frames out of [data] and returns the serial from the first
+     * frame whose cmdSet is 0 and cmdId equals [expectCmdId] — taking the
+     * longest printable ASCII run (8–32 chars) in that frame's payload.
+     */
+    private fun parseQueryResponse(data: ByteArray, expectCmdId: Int): String {
+        var i = 0
+        while (i < data.size) {
+            if (data[i] != 0x55.toByte()) { i++; continue }
+            if (i + 13 > data.size) break
+            val len = (data[i + 1].toInt() and 0xFF) or ((data[i + 2].toInt() and 0x03) shl 8)
+            if (len < 13 || i + len > data.size) { i++; continue }
+            val cmdSet = data[i + 9].toInt() and 0xFF
+            val cmdId = data[i + 10].toInt() and 0xFF
+            if (cmdSet == 0 && cmdId == expectCmdId) {
+                val payload = data.copyOfRange(i + 11, i + len - 2)
+                val s = longestPrintable(payload, 8, 32)
+                if (isValidSerial(s)) return s
+            }
+            i += len
+        }
+        return ""
+    }
+
+    /**
+     * Extracts a serial from raw bytes: a direct match on the printed 1581…
+     * serial, then the same match after reassembling 55 CC 30 75 chunks.
+     */
+    private fun extractSerial(data: ByteArray): String {
+        SERIAL_REGEX.find(String(data, Charsets.ISO_8859_1))?.let { return it.value }
+        val reassembled = reassembleChunks(data)
+        if (reassembled.isNotEmpty()) {
+            SERIAL_REGEX.find(String(reassembled, Charsets.ISO_8859_1))?.let { return it.value }
+        }
+        return ""
+    }
+
+    /** Reassembles 55 CC 30 75 [len:u32 LE] [payload] chunks into one buffer. */
+    private fun reassembleChunks(data: ByteArray): ByteArray {
+        val out = ByteArrayOutputStream()
+        var i = indexOf(data, CHUNK_MAGIC, 0)
+        while (i in 0..(data.size - 8)) {
+            val len = (data[i + 4].toInt() and 0xFF) or ((data[i + 5].toInt() and 0xFF) shl 8) or
+                      ((data[i + 6].toInt() and 0xFF) shl 16) or ((data[i + 7].toInt() and 0xFF) shl 24)
+            val start = i + 8
+            val end = if (len in 1..data.size && start + len <= data.size) start + len else start
+            if (end > start) out.write(data, start, end - start)
+            i = indexOf(data, CHUNK_MAGIC, maxOf(end, i + 9))
+        }
+        return out.toByteArray()
+    }
+
+    private fun indexOf(haystack: ByteArray, needle: ByteArray, from: Int): Int {
+        if (needle.isEmpty()) return -1
+        var i = maxOf(from, 0)
+        val last = haystack.size - needle.size
+        while (i <= last) {
+            var j = 0
+            while (j < needle.size && haystack[i + j] == needle[j]) j++
+            if (j == needle.size) return i
+            i++
+        }
+        return -1
+    }
+
+    private fun longestPrintable(data: ByteArray, min: Int, max: Int): String {
+        var best = ""
+        val sb = StringBuilder()
+        for (b in data) {
+            val c = b.toInt() and 0xFF
+            if (c in 33..126) {
+                sb.append(c.toChar())
+            } else {
+                if (sb.length in min..max && sb.length > best.length) best = sb.toString()
+                sb.setLength(0)
+            }
+        }
+        if (sb.length in min..max && sb.length > best.length) best = sb.toString()
+        return best
     }
 
     /**
@@ -563,6 +732,23 @@ class DumlTransport {
 
         /** TCP connect timeout for all socket opens to the DUML proxy. */
         private const val CONNECT_TIMEOUT_MS = 2000
+
+        /** The printed aircraft serial pattern (starts 1581, 16–22 chars). */
+        private val SERIAL_REGEX = Regex("1581[0-9A-Z]{12,18}")
+        /** Marker for length-prefixed telemetry chunks: 55 CC 30 75. */
+        private val CHUNK_MAGIC = byteArrayOf(0x55, 0xCC.toByte(), 0x30, 0x75)
+
+        /**
+         * A serial is usable if it is 8–32 chars, alphanumeric, and not the
+         * literal "unknown". Accepts formats beyond the printed 1581… serial
+         * (e.g. the serial returned by an active version/serial query).
+         */
+        fun isValidSerial(serial: String?): Boolean {
+            if (serial.isNullOrBlank()) return false
+            if (serial.equals("unknown", ignoreCase = true)) return false
+            if (serial.length < 8 || serial.length > 32) return false
+            return serial.all { it.isLetterOrDigit() }
+        }
 
         /**
          * A frame series counts as sent only if it was non-empty and every

--- a/app/src/main/java/com/freefcc/app/FccViewModel.kt
+++ b/app/src/main/java/com/freefcc/app/FccViewModel.kt
@@ -33,6 +33,8 @@ data class AppState(
     val isHardwareBusy: Boolean = false,
     val busyProgress: Float = 0f,
     val aircraftSerial: String = "",
+    val manualSerial: String = "",
+    val isProbingSerial: Boolean = false,
     val controllerModel: String = "",
     val deviceInfo: String = "",
     val isQueryingInfo: Boolean = false,
@@ -65,7 +67,7 @@ data class AppState(
 class FccViewModel(private val app: Application) : AndroidViewModel(app) {
 
     companion object {
-        const val APP_VERSION = "1.5.4"
+        const val APP_VERSION = "1.5.5"
 
         /**
          * Aircraft model codes *hinted* to support the DJI Cellular Dongle 2 / 4G.
@@ -104,9 +106,27 @@ class FccViewModel(private val app: Application) : AndroidViewModel(app) {
         }
         // Restore the cached aircraft serial from a previous session so the
         // user does not have to re-probe before 4G if the drone is the same.
+        // A manually-entered serial takes priority and is shown in the field.
+        val manual = prefs.getString("manual_aircraft_sn", "").orEmpty()
         val cachedSerial = prefs.getString("aircraft_serial", "").orEmpty()
-        if (cachedSerial.isNotEmpty()) {
-            update { copy(aircraftSerial = cachedSerial) }
+        val shown = if (manual.isNotEmpty()) manual else cachedSerial
+        update { copy(manualSerial = manual, aircraftSerial = shown) }
+    }
+
+    /**
+     * Stores (or clears) a manually-entered aircraft serial. A manual serial
+     * takes priority over auto-detection everywhere — the reliable fallback
+     * when the controller never surfaces the serial on its own.
+     */
+    fun setManualSerial(serial: String) {
+        val s = serial.trim().uppercase()
+        prefs.edit().putString("manual_aircraft_sn", s).apply()
+        if (s.isEmpty()) {
+            update { copy(manualSerial = "") }
+            log("Manual serial cleared — auto-detection will be used")
+        } else {
+            update { copy(manualSerial = s, aircraftSerial = s) }
+            log(if (DumlTransport.isValidSerial(s)) "Manual serial set: $s" else "Manual serial set: $s (note: unusual format)")
         }
     }
 
@@ -695,18 +715,26 @@ class FccViewModel(private val app: Application) : AndroidViewModel(app) {
             log("Hardware busy — please wait for the current operation to finish.")
             return
         }
-        log("Probing for aircraft serial...")
+        log("Reading aircraft serial...")
+        update { copy(isProbingSerial = true) }
         runOnIO {
             try {
-                val serial = transport.probeSerial(2000)
+                // Active query first (fast, deterministic when the aircraft is
+                // linked), then a longer passive telemetry listen as a fallback.
+                var serial = transport.probeSerialActive(800)
+                if (serial.isEmpty()) {
+                    log("No reply to the serial query — listening for telemetry (up to 8s)...")
+                    serial = transport.probeSerial(8000)
+                }
                 if (serial.isNotEmpty()) {
                     update { copy(aircraftSerial = serial) }
                     prefs.edit().putString("aircraft_serial", serial).apply()
                     log("Aircraft serial: $serial (cached)")
                 } else {
-                    log("No serial detected — is the aircraft powered on?")
+                    log("No serial detected — power on and link the aircraft with the live view up, or enter it manually.")
                 }
             } finally {
+                update { copy(isProbingSerial = false) }
                 endHardwareOp()
             }
         }
@@ -927,24 +955,39 @@ class FccViewModel(private val app: Application) : AndroidViewModel(app) {
         return false
     }
 
-    /** Returns the cached serial, or probes the controller if not yet known. Caches the result in SharedPreferences. */
+    /**
+     * Resolves the aircraft serial for 4G, in priority order:
+     *   1. A manually-entered serial (always wins).
+     *   2. The serial from this session / a previous session (cache).
+     *   3. An active version/serial query to the aircraft.
+     *   4. A longer passive telemetry listen.
+     * The first non-empty result is cached in SharedPreferences.
+     */
     private fun getOrProbeSerial(): String {
-        var serial = _state.value.aircraftSerial
-        if (serial.isEmpty()) {
-            // Fall back to a serial persisted in a previous session.
-            serial = prefs.getString("aircraft_serial", "").orEmpty()
-            if (serial.isNotEmpty()) {
-                update { copy(aircraftSerial = serial) }
-            }
+        // 1. Manual serial takes priority — trust exactly what the user typed,
+        //    whatever the format (do NOT re-validate; they entered it on purpose).
+        val manual = prefs.getString("manual_aircraft_sn", "").orEmpty()
+        if (manual.isNotEmpty()) {
+            update { copy(aircraftSerial = manual) }
+            return manual
         }
-        if (serial.isEmpty()) {
-            log("Probing for aircraft serial...")
-            serial = transport.probeSerial(2000)
-            if (serial.isNotEmpty()) {
-                update { copy(aircraftSerial = serial) }
-                prefs.edit().putString("aircraft_serial", serial).apply()
-                log("Aircraft serial: $serial (cached)")
-            }
+
+        // 2. Cached from this or a previous session.
+        var serial = _state.value.aircraftSerial
+        if (serial.isEmpty()) serial = prefs.getString("aircraft_serial", "").orEmpty()
+        if (serial.isNotEmpty()) {
+            update { copy(aircraftSerial = serial) }
+            return serial
+        }
+
+        // 3. Active query, then 4. longer passive listen.
+        log("Reading aircraft serial...")
+        serial = transport.probeSerialActive(800)
+        if (serial.isEmpty()) serial = transport.probeSerial(8000)
+        if (serial.isNotEmpty()) {
+            update { copy(aircraftSerial = serial) }
+            prefs.edit().putString("aircraft_serial", serial).apply()
+            log("Aircraft serial: $serial (cached)")
         }
         return serial
     }

--- a/app/src/main/java/com/freefcc/app/MainActivity.kt
+++ b/app/src/main/java/com/freefcc/app/MainActivity.kt
@@ -312,6 +312,46 @@ private fun FccPage(state: AppState, viewModel: FccViewModel) {
                         else "Sends 4G activation frames to the aircraft. No status is read back — check the DJI Fly app or Cellular Dongle to confirm.",
                         TextGray
                     )
+
+                    Spacer(Modifier.height(16.dp))
+
+                    // Aircraft serial — embedded in every 4G frame. Auto-detect
+                    // (active query, then telemetry) or type it in if detection fails.
+                    var serialField by remember(state.aircraftSerial, state.manualSerial) {
+                        mutableStateOf(state.manualSerial.ifEmpty { state.aircraftSerial })
+                    }
+                    OutlinedTextField(
+                        value = serialField,
+                        onValueChange = { serialField = it.trim() },
+                        label = { Text("Aircraft serial") },
+                        placeholder = { Text("auto-detected, or type it") },
+                        singleLine = true,
+                        enabled = !state.isHardwareBusy,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = TextWhite,
+                            unfocusedTextColor = TextWhite,
+                            focusedBorderColor = Amber,
+                            unfocusedBorderColor = TextGray,
+                            focusedLabelColor = Amber,
+                            unfocusedLabelColor = TextGray,
+                            focusedPlaceholderColor = TextGray,
+                            unfocusedPlaceholderColor = TextGray,
+                            cursorColor = Amber
+                        )
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    GlowButton(
+                        if (state.isProbingSerial) "Reading serial…" else "Read serial from aircraft",
+                        Cyan, filled = false, enabled = !state.isHardwareBusy
+                    ) { viewModel.probeSerial() }
+                    if (serialField.isNotBlank() && serialField != state.manualSerial) {
+                        Spacer(Modifier.height(8.dp))
+                        GlowButton("Use this serial for 4G", Cyan, filled = false, enabled = !state.isHardwareBusy) {
+                            viewModel.setManualSerial(serialField)
+                        }
+                    }
+
                     Spacer(Modifier.height(20.dp))
 
                     if (state.is4gBusy) {


### PR DESCRIPTION
Fixes the serial detection that was failing in the field (the root of the 4G "serial too short" reports).

- **Active serial query** — asks the aircraft/controller for its serial (version/serial inquiry, cmdSet 0, cmdId 87/1) instead of only passively waiting.
- **TLV parsing** — reassembles `55 CC 30 75` length-prefixed telemetry chunks.
- **Longer passive listen** (up to 8s) as a fallback.
- **Broader acceptance** — any 8–32 char alphanumeric serial, not just `1581…` (some aircraft use other formats).
- **Manual serial entry** — a field in the 4G card that always overrides auto-detect (addresses #32).

FCC path untouched. Built + unit tests green locally.